### PR TITLE
Switch "iat" to seconds from ms. Fixes jwt expire times.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ function issueJWT(user) {
 
   const payload = {
     sub: _id,
-    iat: Date.now()
+    iat: Math.floor(Date.now() / 1000)
   };
 
   const signedToken = jsonwebtoken.sign(payload, PRIV_KEY, { expiresIn: expiresIn, algorithm: 'RS256' });


### PR DESCRIPTION
A fix for issue #11 